### PR TITLE
CSS fixes for the error/notice box

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Polymer template binding is [known to have problems with arrays](https://github.
 4. Push to the branch: `git push origin my-new-feature`
 5. Submit a pull request :D
 
-## Development
+## Development and Testing
 
 In order to develop it locally we suggest to use [polyserve](https://npmjs.com/polyserve) tool to handle bower paths gently.
 

--- a/puppet-client.html
+++ b/puppet-client.html
@@ -66,17 +66,15 @@ All the changes from server are also received and propagated to your HTML.
                 color: #FFFFFF;
             }
             .tappable {
-                display: block;
                 cursor: pointer;
-                text-decoration: none;
             }
             .tappable span {
                 text-decoration: underline;
             }
         </style>
-        <div class="box-container" hidden$="{{!showReconnectingIn}}"><a class="box notice tappable" on-tap="reconnectNow"><strong>Not connected.</strong> Connecting in {{reconnectionSeconds}}s... <span>Retry now</span></a></div>
+        <div class="box-container" hidden$="{{!showReconnectingIn}}"><div class="box notice tappable" on-tap="reconnectNow"><strong>Not connected.</strong> Connecting in {{reconnectionSeconds}}s... <span>Retry now</span></div></div>
         <div class="box-container" hidden$="{{!showReconnectingNow}}"><div class="box notice"><strong>Connecting now...</strong></div></div>
-        <div class="box-container" hidden$="{{!showConnectionError}}"><a class="box error tappable" on-tap="reload"><strong>Connection error.</strong> See console for details. <span>Click here to reload</span></a></div>
+        <div class="box-container" hidden$="{{!showConnectionError}}"><div class="box error tappable" on-tap="reload"><strong>Connection error.</strong> See console for details. <span>Click here to reload</span></div></div>
     </template>
 
 <script>

--- a/puppet-client.html
+++ b/puppet-client.html
@@ -52,33 +52,31 @@ All the changes from server are also received and propagated to your HTML.
                 text-align: center;
                 padding: 5px 0;
             }
-            .box a {
-                color: inherit;
-                text-decoration: underline;
-            }
-            .box.error.reload span {
-              text-decoration: underline;
-            }
             @media only screen and (max-width: 640px) {
                 .box { width: 100%; }
             }
             .notice {
                 background-color: #fff4cc;
                 border-color: #ffe070;
+                color: #000;
             }
             .error {
                 background-color: #DB0F13;
                 border-color: #A11517;
                 color: #FFFFFF;
             }
-            .reload {
-              display: block;
-              cursor: pointer;
+            .tappable {
+                display: block;
+                cursor: pointer;
+                text-decoration: none;
+            }
+            .tappable span {
+                text-decoration: underline;
             }
         </style>
-        <div class="box-container" hidden$="{{!showReconnectingIn}}"><div class="box notice"><strong>Not connected.</strong> Connecting in {{reconnectionSeconds}}s... <a href="" on-tap="reconnectNow">Retry now</a></div></div>
+        <div class="box-container" hidden$="{{!showReconnectingIn}}"><a class="box notice tappable" on-tap="reconnectNow"><strong>Not connected.</strong> Connecting in {{reconnectionSeconds}}s... <span>Retry now</span></a></div>
         <div class="box-container" hidden$="{{!showReconnectingNow}}"><div class="box notice"><strong>Connecting now...</strong></div></div>
-        <div class="box-container" hidden$="{{!showConnectionError}}"><a class="box error reload" on-tap="reload"><strong>Connection error.</strong> See console for details. <span>Click here to reload</span></a></div>
+        <div class="box-container" hidden$="{{!showConnectionError}}"><a class="box error tappable" on-tap="reload"><strong>Connection error.</strong> See console for details. <span>Click here to reload</span></a></div>
     </template>
 
 <script>

--- a/test/d-b-n_smoke/reconnection.html
+++ b/test/d-b-n_smoke/reconnection.html
@@ -68,7 +68,7 @@
                 var closeEvent = {reason: 'thereason', code:1};
                 var boxErrorMsg = 'Connection error. See console for details.';
                 puppet.network._ws.close(closeEvent);
-                expect(container.querySelector("a.box.error.reload").innerText).to.contain(boxErrorMsg);
+                expect(container.querySelector("div.box.error.tappable").innerText).to.contain(boxErrorMsg);
             });
 
             it('and log error reason to the console', function() {


### PR DESCRIPTION
@mmnosek it seems that my code review was a little bit too uncautious. Today I have noticed to problems:

1. When I put the mouse cursor over the error text, the whole text gets underlined
2. The notice box is not tappable in the same way as the error box is
3. The `<a>` element is used without the `href` attribute, which is wrong

This PR attempts to fix all these problems.